### PR TITLE
Allow relying on ale_linters to activate lsp-ale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ endif
 
 " Set 'vim-lsp' linter
 let g:ale_linters = {
-    \   'go': ['vim-lsp', 'golint'],
+    \   'go': ['golint'], " vim-lsp is implicitly active
     \ }
 ```
 

--- a/doc/vim-lsp-ale.txt
+++ b/doc/vim-lsp-ale.txt
@@ -97,7 +97,7 @@ Behavior of vim-lsp-ale can be customized with some global variables.
 ------------------------------------------------------------------------------
 *g:lsp_ale_auto_config_vim_lsp* (Default: |v:true|)
 
-When |v:true| is set to true, vim-lsp-ale automatically sets several variables
+When |v:true| is set, vim-lsp-ale automatically sets several variables
 for configuring vim-lsp not to show diagnostics results in vim-lsp side.
 
 At the time of writing, setting |v:true| is the same as:
@@ -115,7 +115,7 @@ vim-lsp so that you can configure them by yourself.
 ------------------------------------------------------------------------------
 *g:lsp_ale_auto_config_ale* (Default: |v:true|)
 
-When |v:true| is set to true, vim-lsp-ale automatically sets several variables
+When |v:true| is set, vim-lsp-ale automatically sets several variables
 for configuring ALE not to start LSP server process.
 
 At the time of writing, setting |v:true| is the same as:
@@ -125,6 +125,21 @@ At the time of writing, setting |v:true| is the same as:
 When |v:false| is set, vim-lsp-ale does not set any variables to configure
 ALE so that you can configure them by yourself.
 
+------------------------------------------------------------------------------
+*g:lsp_ale_auto_enable_linter* (Default: |v:true|)
+
+When |v:true| is set, vim-lsp-ale automatically enables itself as a linter for
+all filetypes. It does not modify |g:ale_linters|.
+
+When |v:false| is set, vim-lsp-ale is only active when configured as a linter
+for a filetype:
+>
+  let g:ale_linters = {
+      \   'go':     ['vim-lsp'],
+      \   'lua':    ['vim-lsp'],
+      \   'python': ['vim-lsp'],
+      \ }
+<
 ------------------------------------------------------------------------------
 *g:lsp_ale_diagnostics_severity* (Default: "information")
 

--- a/plugin/lsp_ale.vim
+++ b/plugin/lsp_ale.vim
@@ -4,6 +4,7 @@ endif
 let g:loaded_lsp_ale = 1
 
 let g:lsp_ale_diagnostics_severity = get(g:, 'lsp_ale_diagnostics_severity', 'information')
+let g:lsp_ale_auto_enable_linter = get(g:, 'lsp_ale_auto_enable_linter', v:true)
 
 if get(g:, 'lsp_ale_auto_config_vim_lsp', v:true)
     " Enable diagnostics and disable all functionalities to show error


### PR DESCRIPTION
Fix #1.

Limit activation to when vim-lsp is set as a linter in ale or when
g:lsp_ale_auto_enable_linter is set.

Fix some documentation typos.

Defaulting to auto activation to maintain old behaviour. I briefly looked at the tests and don't see 'vim-lsp' being set anywhere. But there's also functions like `ale#other_source#last_show_results()` called that don't exist in my ale, so maybe the tests are all broken?