### PR TITLE
Check first `b:ale_linters` then fallback for "vim-lsp" to `g:ale_linters`

### DIFF
--- a/autoload/lsp/ale.vim
+++ b/autoload/lsp/ale.vim
@@ -75,7 +75,7 @@ function! s:is_active_linter() abort
     if g:lsp_ale_auto_enable_linter
         return v:true
     endif
-    let active_linters = get(g:ale_linters, &filetype, [])
+    let active_linters = get(b:, ale_linters, get(g:ale_linters, &filetype, []))
     return index(active_linters, 'vim-lsp') >= 0
 endf
 

--- a/autoload/lsp/ale.vim
+++ b/autoload/lsp/ale.vim
@@ -75,7 +75,7 @@ function! s:is_active_linter() abort
     if g:lsp_ale_auto_enable_linter
         return v:true
     endif
-    let active_linters = get(b:, ale_linters, get(g:ale_linters, &filetype, []))
+    let active_linters = get(b:, 'ale_linters', get(g:ale_linters, &filetype, []))
     return index(active_linters, 'vim-lsp') >= 0
 endf
 


### PR DESCRIPTION
When `g:lsp_ale_auto_enable_linter` is set to false, then first check more specific variable `b:ale_linters` if it contains vim-lsp as linter.  
In case buffer variable is not set, then fall back to the global `g:ale_linters` and check whether vim-lsp is there.